### PR TITLE
Correct Bantul location mapping for Sedayu

### DIFF
--- a/PropertyRAG.py
+++ b/PropertyRAG.py
@@ -67,7 +67,7 @@ class PropertyRAG:
                 "pleret",
                 "pundong",
                 "sanden",
-                "dayu",
+                "sedayu",
                 "sewon",
                 "srandakan",
             ],


### PR DESCRIPTION
## Summary
- Fix typo in `PropertyRAG.py` by renaming Bantul subdistrict `dayu` to `sedayu`.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a76ab4c108321baf55bbe7c2102c9